### PR TITLE
Set flight signing values for bootmgr

### DIFF
--- a/OfflineInsiderEnroll.cmd
+++ b/OfflineInsiderEnroll.cmd
@@ -214,6 +214,7 @@ echo Applying changes...
 call :RESET_INSIDER_CONFIG 1>NUL 2>NUL
 call :ADD_INSIDER_CONFIG 1>NUL 2>NUL
 bcdedit /set {current} flightsigning yes >nul 2>&1
+bcdedit /set {bootmgr} flightsigning yes >nul 2>&1
 echo Done.
 
 echo.
@@ -226,6 +227,7 @@ goto :EOF
 echo Applying changes...
 call :RESET_INSIDER_CONFIG 1>nul 2>nul
 bcdedit /deletevalue {current} flightsigning >nul 2>&1
+bcdedit /deletevalue {bootmgr} flightsigning >nul 2>&1
 echo Done.
 
 echo.


### PR DESCRIPTION
Enrolling in the WIP sets the flightsigning value not only for the OS partition, but also for the boot manager, so this should be set/unset when enrolling/un-enrolling.